### PR TITLE
Feature/csp block external js

### DIFF
--- a/src/main/java/org/example/springmvc/auth/NonceFilter.java
+++ b/src/main/java/org/example/springmvc/auth/NonceFilter.java
@@ -4,6 +4,7 @@ import jakarta.servlet.FilterChain;
 import jakarta.servlet.ServletException;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 import org.springframework.web.filter.OncePerRequestFilter;
 
@@ -12,6 +13,7 @@ import java.security.SecureRandom;
 import java.util.Base64;
 
 @Component
+@Order(1)
 public class NonceFilter extends OncePerRequestFilter {
 
     private static final SecureRandom secureRandom = new SecureRandom();
@@ -32,7 +34,9 @@ public class NonceFilter extends OncePerRequestFilter {
         response.setHeader("Content-Security-Policy",
                 "default-src 'self'; " +
                         "script-src 'self' 'nonce-" + nonce + "'; " +
-                        "style-src 'self';");
+                        "style-src 'self'; " +
+                        "object-src 'none'; " +
+                        "base-uri 'self';");
 
         filterChain.doFilter(request, response);
     }


### PR DESCRIPTION
Closes #50

NonceFilter generates a unique per-request nonce and applies a Content Security Policy (CSP) header to restrict which scripts can run in the application.

CSP Policy that is implemented:
default-src self: Only allow resources from the same origin
script-src self nonce-<generated>:  Allow scripts from the same origin and inline scripts that include the generated nonce
style-src self: Only allow styles from the same origin
object-src none: Disable plugins such as Flash
base-uri self: Restrict base URLs

This blocks scripts from untrusted external domains and helps mitigate Cross-Site Scripting (XSS) attacks.


The nonce is exposed to Thymeleaf templates through the cspNonce request attribute.
When inline JavaScript is required, it must include the nonce value to be allowed by the CSP.

Because the nonce is generated per request, injected or malicious scripts without the correct nonce will be blocked by the browser

This prepares the application for safely adding dynamic client-side behavior while maintaining strong CSP protections.