### PR TITLE
Feature/csrf

### DIFF
--- a/src/main/java/org/example/springmvc/auth/SecurityConfig.java
+++ b/src/main/java/org/example/springmvc/auth/SecurityConfig.java
@@ -8,6 +8,8 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.security.web.SecurityFilterChain;
 
+import static org.springframework.security.config.Customizer.withDefaults;
+
 @Configuration
 @EnableWebSecurity
 public class SecurityConfig {
@@ -38,8 +40,7 @@ public class SecurityConfig {
                         .deleteCookies("JSESSIONID")
                         .permitAll()
                 )
-                .csrf(csrf -> csrf
-                );
+                .csrf(withDefaults());
 
         return http.build();
     }

--- a/src/main/resources/templates/auth/login.html
+++ b/src/main/resources/templates/auth/login.html
@@ -24,6 +24,7 @@
 
     <form style="display:flex; flex-direction:column; gap:10px;"
           th:action="@{/login}" method="post">
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
 
         <div style="display:flex; gap:10px; align-items:center;">
             <label style="width:120px;">Email</label>

--- a/src/main/resources/templates/bookings/create.html
+++ b/src/main/resources/templates/bookings/create.html
@@ -106,6 +106,7 @@
     </form>
 
     <form th:if="${cars != null}" th:action="@{/bookings}" th:object="${booking}" method="post">
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
         <input type="hidden" th:field="*{driverId}">
         <input type="hidden"
                name="startTime"

--- a/src/main/resources/templates/cars/create.html
+++ b/src/main/resources/templates/cars/create.html
@@ -14,6 +14,7 @@
 <div style="display: flex; text-align: center; align-items: center; flex-direction: column; margin-top: 0px">
 
     <form style="display:flex; flex-direction:column; gap:10px;" th:action="@{/cars}" th:object="${car}" method="post">
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
 
         <div style="display:flex; gap:10px; align-items:center;">
             <label for="make" style="width:120px;">Make</label>

--- a/src/main/resources/templates/drivers/create.html
+++ b/src/main/resources/templates/drivers/create.html
@@ -16,6 +16,7 @@
 <div style="display: flex; text-align: center; align-items: center; flex-direction: column; margin-top: 0px">
 
     <form style="display:flex; flex-direction:column; gap:10px;" th:action="@{/drivers/new}" th:object="${driver}" method="post">
+        <input type="hidden" th:name="${_csrf.parameterName}" th:value="${_csrf.token}" />
 
         <div style="display:flex; gap:10px; align-items:center;">
             <label for="fname" style="width:120px;">First Name</label>


### PR DESCRIPTION
Closes #51 

Enabled CSRF protection using Spring Security defaults and added CSRF tokens to all POST forms in the application

Enabled CSRF protection in SecurityConfig using .csrf(withDefaults())
Added CSRF hidden fields to all POST forms:

Login form
Logout form
Create car form
Become driver form
Booking creation form

(I Verified that CSRF tokens are sent in the request payload via browser DevTools)

In the future, when adding the update/delete functionality we need to ensure that we include the same CSRF token in the html files.

For POST same _csrf code line is used
For PUT/PATCH, DELETE we need _method + _csrf to tell Spring the method
